### PR TITLE
fix: refresh_token

### DIFF
--- a/itd/client.py
+++ b/itd/client.py
@@ -406,12 +406,8 @@ class Client:
 
         self.access_token = res.json().get('accessToken') or res.json()['token']
         self.access_token_data = AccessToken.model_validate(decode_jwt_payload(self.access_token))
-        if 'set-cookie' in res.headers:
-            for ex in res.headers['set-cookie'].split('; '):
-                if 'refresh_token' in ex:
-                    key, val = ex.split('=')
-                    if len(val) != 0:
-                        self.refresh_token = val
+        self.refresh_token = res.cookies['refresh_token']
+
         assert self.access_token
         return self.access_token
 

--- a/itd/client.py
+++ b/itd/client.py
@@ -406,7 +406,8 @@ class Client:
 
         self.access_token = res.json().get('accessToken') or res.json()['token']
         self.access_token_data = AccessToken.model_validate(decode_jwt_payload(self.access_token))
-        self.refresh_token = res.cookies['refresh_token']
+        if 'refresh_token' in res.cookies:
+            self.refresh_token = res.cookies['refresh_token']
 
         assert self.access_token
         return self.access_token

--- a/itd/client.py
+++ b/itd/client.py
@@ -406,7 +406,12 @@ class Client:
 
         self.access_token = res.json().get('accessToken') or res.json()['token']
         self.access_token_data = AccessToken.model_validate(decode_jwt_payload(self.access_token))
-
+        if 'set-cookie' in res.headers:
+            for ex in res.headers['set-cookie'].split('; '):
+                if 'refresh_token' in ex:
+                    key, val = ex.split('=')
+                    if len(val) != 0:
+                        self.refresh_token = val
         assert self.access_token
         return self.access_token
 


### PR DESCRIPTION
Сделали что с каждым refresh обновляется токен. Сделал чтобы client.refresh_token был актуальным, в куки requests сам всё делает. Нужно в доку где-то добавить, что теперь нужно так делать:

```python
from itd import ITDClient, User

with open("refresh_token.txt", 'r') as file:
    refresh_token = file.readline()

c = ITDClient(refresh_token)

u = User("nokie")
print(u.id)
c.refresh_auth()
u = User("nokie")
print(u.id)

with open("refresh_token.txt", 'w') as file:
    file.write(c.refresh_token)
```

Или так как-то.
```python
from itd import ITDClient, User

c = None

def main():
    global c
    with open("refresh_token.txt", 'r') as file:
        refresh_token = file.readline().strip()
    c = ITDClient(refresh_token)

    u = User("nokie")
    print(u.id)

    c.refresh_auth()
    raise ValueError
    u = User("nokie")
    print(u.id)

if __name__ == "__main__":
    try:
        main()
    except Exception as ex:
        if c is not None:
            with open("refresh_token.txt", 'w') as file:
                file.write(c.refresh_token)
        raise ex
```
