### PR TITLE
fix(client): refresh access token for requests without auth level

### DIFF
--- a/itd/api/auth.py
+++ b/itd/api/auth.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from requests import Response
-
-from itd.base import api_wrapper
 from itd.enums import AuthLevel
 from itd.exceptions import (
     CaptchaFailedError,
@@ -17,26 +14,25 @@ from itd.exceptions import (
     SessionNotFoundError,
     SessionRevokedError
 )
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper(SessionExpiredError(), SessionNotFoundError(), SessionRevokedError())
-def refresh_token(client: Client) -> Response:
-    return client.request('post', 'v1/auth/refresh', level=AuthLevel.REFRESH)
+@endpoint('post', 'v1/auth/refresh', SessionExpiredError(), SessionNotFoundError(), SessionRevokedError(), level=AuthLevel.REFRESH)
+def refresh_token(client: Client): ...
 
 
-@api_wrapper(InvalidPasswordError(), SamePasswordError(), InvalidOldPasswordError())
-def change_password(client: Client, old: str, new: str) -> Response:
-    return client.request('post', 'v1/auth/change-password', {'newPassword': new, 'oldPassword': old})
+@endpoint('post', 'v1/auth/change-password', InvalidPasswordError(), SamePasswordError(), InvalidOldPasswordError())
+def change_password(client: Client, old: str, new: str):
+    return {'newPassword': new, 'oldPassword': old}
 
 
-@api_wrapper()
-def logout(client: Client) -> Response:
-    return client.request('post', 'v1/auth/logout', level=AuthLevel.REFRESH)
+@endpoint('post', 'v1/auth/logout', level=AuthLevel.REFRESH)
+def logout(client: Client): ...
 
 
-@api_wrapper(InvalidCredentials(), CaptchaFailedError(), EmailDomainNotAllowed())
+@endpoint('post', 'v1/auth/sign-in', InvalidCredentials(), CaptchaFailedError(), EmailDomainNotAllowed(), level=AuthLevel.NO)
 def sign_in(client: Client, email: str, password: str, turnstile: str):
-    return client.request('post', 'v1/auth/sign-in', {'email': email, 'password': password, 'turnstileToken': turnstile}, level=AuthLevel.NO)
+    return {'email': email, 'password': password, 'turnstileToken': turnstile}

--- a/itd/api/comments.py
+++ b/itd/api/comments.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from itd.base import api_wrapper
 from itd.exceptions import AlreadyDeletedError, BannedWordError, ForbiddenError, NotFoundError, RequiresSubscriptionError, ValidationError
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper(
+@endpoint(
+    'post',
+    'posts/{post_id}/comments',
     ValidationError(),
     NotFoundError('Post'),
     BannedWordError('Comment'),
@@ -18,10 +20,12 @@ if TYPE_CHECKING:
     RequiresSubscriptionError('Video uploading')
 )
 def add_comment(client: Client, post_id: UUID, content: str | None = None, attachment_ids: list[UUID] = []):
-    return client.request('post', f'posts/{post_id}/comments', {'content': content or '', "attachmentIds": list(map(str, attachment_ids))})
+    return {'content': content or '', 'attachmentIds': list(map(str, attachment_ids))}
 
 
-@api_wrapper(
+@endpoint(
+    'post',
+    'comments/{comment_id}/replies',
     ValidationError(),
     NotFoundError('Comment'),
     NotFoundError('User', res_check=lambda res: res.status_code == 500 and 'Failed query' in res.text),
@@ -30,36 +34,31 @@ def add_comment(client: Client, post_id: UUID, content: str | None = None, attac
     RequiresSubscriptionError('Video uploading')
 )
 def add_reply_comment(client: Client, comment_id: UUID, author_id: UUID, content: str | None = None, attachment_ids: list[UUID] = []):
-    return client.request(
-        'post', f'comments/{comment_id}/replies', {'content': content or '', 'replyToUserId': str(author_id), "attachmentIds": list(map(str, attachment_ids))}
-    )
+    return {'content': content or '', 'replyToUserId': str(author_id), 'attachmentIds': list(map(str, attachment_ids))}
 
 
-@api_wrapper(ValidationError(), NotFoundError('Post'))
+@endpoint('get', 'posts/{post_id}/comments', ValidationError(), NotFoundError('Post'))
 def get_comments(client: Client, post_id: UUID, cursor: int = 0, limit: int = 20, sort: str = 'popular'):
-    return client.request('get', f'posts/{post_id}/comments', {'limit': limit, 'sort': sort, 'cursor': cursor})
+    return {'limit': limit, 'sort': sort, 'cursor': cursor}
 
 
-@api_wrapper(NotFoundError('Comment'))
-def like_comment(client: Client, id: UUID):
-    return client.request('post', f'comments/{id}/like')
+@endpoint('post', 'comments/{id}/like', NotFoundError('Comment'))
+def like_comment(client: Client, id: UUID): ...
 
 
-@api_wrapper(NotFoundError('Comment'))
-def unlike_comment(client: Client, id: UUID):
-    return client.request('delete', f'comments/{id}/like')
+@endpoint('delete', 'comments/{id}/like', NotFoundError('Comment'))
+def unlike_comment(client: Client, id: UUID): ...
 
 
-@api_wrapper(NotFoundError('Comment'), AlreadyDeletedError('Comment'), ForbiddenError('delete comment'))
-def delete_comment(client: Client, id: UUID):
-    return client.request('delete', f'comments/{id}')
+@endpoint('delete', 'comments/{id}', NotFoundError('Comment'), AlreadyDeletedError('Comment'), ForbiddenError('delete comment'))
+def delete_comment(client: Client, id: UUID): ...
 
 
-@api_wrapper(ValidationError(), NotFoundError('Comment'))
+@endpoint('get', 'comments/{id}/replies', ValidationError(), NotFoundError('Comment'))
 def get_replies(client: Client, id: UUID, page: int = 1, limit: int = 50):
-    return client.request('get', f'comments/{id}/replies', {'page': page, 'limit': limit})
+    return {'page': page, 'limit': limit}
 
 
-@api_wrapper(ValidationError(), NotFoundError('Comment'), ForbiddenError('edit comment'))
+@endpoint('patch', 'comments/{id}', ValidationError(), NotFoundError('Comment'), ForbiddenError('edit comment'))
 def edit_comment(client: Client, id: UUID, content: str):
-    return client.request('patch', f'comments/{id}', {'content': content})
+    return {'content': content}

--- a/itd/api/dwell.py
+++ b/itd/api/dwell.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from itd.base import api_wrapper
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper()
+@endpoint('post', 'v1/i')
 def send_views(client: Client, objects: list[dict], sid: UUID):
-    return client.request('post', 'v1/i', {'e': objects, 'sid': str(sid)})
+    return {'e': objects, 'sid': str(sid)}
 
 
-@api_wrapper()
+@endpoint('post', 'v1/x')
 def send_interactions(client: Client, objects: list[dict], sid: UUID):
-    return client.request('post', 'v1/x', {'e': objects, 'sid': str(sid)})
+    return {'e': objects, 'sid': str(sid)}

--- a/itd/api/etc.py
+++ b/itd/api/etc.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from itd.base import api_wrapper
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper()
-def get_top_clans(client: Client):
-    return client.request('get', 'users/stats/top-clans')
+@endpoint('get', 'users/stats/top-clans')
+def get_top_clans(client: Client): ...
 
 
-@api_wrapper()
-def get_who_to_follow(client: Client):
-    return client.request('get', 'users/suggestions/who-to-follow')
+@endpoint('get', 'users/suggestions/who-to-follow')
+def get_who_to_follow(client: Client): ...

--- a/itd/api/files.py
+++ b/itd/api/files.py
@@ -4,18 +4,17 @@ from _io import BufferedReader
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from itd.base import api_wrapper
 from itd.exceptions import InvalidFileTypeError, ModerationFailedError, TooLargeError, UploadError
+from itd.request import Payload, endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper(UploadError(), ModerationFailedError(), InvalidFileTypeError(), TooLargeError('File', 413))
+@endpoint('post', 'files/upload', UploadError(), ModerationFailedError(), InvalidFileTypeError(), TooLargeError('File', 413))
 def upload_file(client: Client, name: str, data: BufferedReader | bytes):
-    return client.request('post', 'files/upload', files={'file': (name, data)})
+    return Payload(files={'file': (name, data)})
 
 
-@api_wrapper()
-def delete_file(client: Client, id: UUID):
-    return client.request('delete', f'files/{id}')
+@endpoint('delete', 'files/{id}')
+def delete_file(client: Client, id: UUID): ...

--- a/itd/api/hashtags.py
+++ b/itd/api/hashtags.py
@@ -3,24 +3,31 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from itd.base import api_wrapper
 from itd.enums import AuthLevel
 from itd.exceptions import NotFoundError, TooLargeError, ValidationError
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper(ValidationError())
+@endpoint('get', 'hashtags', ValidationError(), level=AuthLevel.NO)
 def search_hashtags(client: Client, query: str, limit: int = 10):
-    return client.request('get', 'hashtags', {'q': query, 'limit': limit}, level=AuthLevel.NO)
+    return {'q': query, 'limit': limit}
 
 
-@api_wrapper(ValidationError())
+@endpoint('get', 'hashtags/trending', ValidationError(), level=AuthLevel.NO)
 def get_hashtags(client: Client, limit: int = 10):
-    return client.request('get', 'hashtags/trending', {'limit': limit}, level=AuthLevel.NO)
+    return {'limit': limit}
 
 
-@api_wrapper(TooLargeError('Hashtag'), NotFoundError('Hashtag', json_check=lambda json: json.get('data', {}).get('hashtag', '') is None), ValidationError())
+@endpoint(
+    'get',
+    'hashtags/{hashtag}/posts',
+    TooLargeError('Hashtag'),
+    NotFoundError('Hashtag', json_check=lambda json: json.get('data', {}).get('hashtag', '') is None),
+    ValidationError(),
+    level=AuthLevel.NO
+)
 def get_posts_by_hashtag(client: Client, hashtag: str, cursor: UUID | None = None, limit: int = 20):
-    return client.request('get', f'hashtags/{hashtag}/posts', {'limit': limit, 'cursor': cursor}, level=AuthLevel.NO)
+    return {'limit': limit, 'cursor': cursor}

--- a/itd/api/notifications.py
+++ b/itd/api/notifications.py
@@ -3,42 +3,36 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from itd.base import api_wrapper
 from itd.exceptions import NotFoundError
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
     from itd.notification import NotificationsSettings
 
 
-@api_wrapper()
+@endpoint('get', 'notifications')
 def get_notifications(client: Client, limit: int = 20, offset: int = 0):
-    return client.request('get', 'notifications', {'limit': limit, 'offset': offset})
+    return {'limit': limit, 'offset': offset}
 
 
-@api_wrapper(NotFoundError('Notification', json_check=lambda json: json.get('success') is False))
-def mark_as_read(client: Client, id: UUID):
-    return client.request('post', f'notifications/{id}/read')
+@endpoint('post', 'notifications/{id}/read', NotFoundError('Notification', json_check=lambda json: json.get('success') is False))
+def mark_as_read(client: Client, id: UUID): ...
 
 
-@api_wrapper()
-def mark_all_as_read(client: Client):
-    return client.request('post', 'notifications/read-all')
+@endpoint('post', 'notifications/read-all')
+def mark_all_as_read(client: Client): ...
 
 
-@api_wrapper()
-def get_unread_notifications_count(client: Client):
-    return client.request('get', 'notifications/count')
+@endpoint('get', 'notifications/count')
+def get_unread_notifications_count(client: Client): ...
 
 
-def stream_notifications(client: Client):
-    return client.request_sse('notifications/stream')
+@endpoint('get', 'notifications/settings')
+def get_notifications_settings(client: Client): ...
 
 
-def get_notifications_settings(client: Client):
-    return client.request('get', 'notifications/settings')
-
-
+@endpoint('put', 'notifications/settings')
 def update_notifications_settings(client: Client, settings: NotificationsSettings, *, old: bool = True, new: bool = True):
     from itd.notification import _NotificationsSettingsNew, _NotificationsSettingsNewPreferences, _NotificationsSettingsOld  # жду фикс circular import день 67
 
@@ -56,4 +50,8 @@ def update_notifications_settings(client: Client, settings: NotificationsSetting
             ).model_dump(mode='json', by_alias=True)
         )
 
-    return client.request('put', 'notifications/settings', data)
+    return data
+
+
+def stream_notifications(client: Client):
+    return client.request_sse('notifications/stream')

--- a/itd/api/pins.py
+++ b/itd/api/pins.py
@@ -2,23 +2,21 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from itd.base import api_wrapper
 from itd.exceptions import PinNotOwnedError
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper()
-def get_pins(client: Client):
-    return client.request('get', 'users/me/pins')
+@endpoint('get', 'users/me/pins')
+def get_pins(client: Client): ...
 
 
-@api_wrapper()
-def remove_pin(client: Client):
-    return client.request('delete', 'users/me/pin')
+@endpoint('delete', 'users/me/pin')
+def remove_pin(client: Client): ...
 
 
-@api_wrapper(PinNotOwnedError())
+@endpoint('put', 'users/me/pin', PinNotOwnedError())
 def set_pin(client: Client, slug: str):
-    return client.request('put', 'users/me/pin', {'slug': slug})
+    return {'slug': slug}

--- a/itd/api/platform.py
+++ b/itd/api/platform.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from itd.enums import AuthLevel
+from itd.request import endpoint
+
 if TYPE_CHECKING:
     from itd.client import Client
-from itd.base import api_wrapper
-from itd.enums import AuthLevel
 
 
-@api_wrapper()
-def get_apps(client: Client):
-    return client.request('get', 'platform/version', level=AuthLevel.NO)
+@endpoint('get', 'platform/version', level=AuthLevel.NO)
+def get_apps(client: Client): ...
 
 
-@api_wrapper()
-def get_changelog(client: Client):
-    return client.request('get', 'platform/changelog', level=AuthLevel.NO)
+@endpoint('get', 'platform/changelog', level=AuthLevel.NO)
+def get_changelog(client: Client): ...

--- a/itd/api/polls.py
+++ b/itd/api/polls.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from itd.base import api_wrapper
 from itd.exceptions import NotFoundError, NotMultipleChoiceError, OptionsNotBelongError
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper(NotFoundError('Post'), NotFoundError('Poll', 'Опрос не найден'), OptionsNotBelongError(), NotMultipleChoiceError())
+@endpoint('post', 'posts/{id}/poll/vote', NotFoundError('Post'), NotFoundError('Poll', 'Опрос не найден'), OptionsNotBelongError(), NotMultipleChoiceError())
 def vote(client: Client, id: UUID, options: list[UUID]):
-    return client.request('post', f'posts/{id}/poll/vote', {'optionIds': [str(option) for option in options]})
+    return {'optionIds': [str(option) for option in options]}

--- a/itd/api/portal.py
+++ b/itd/api/portal.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from itd.enums import AuthLevel
+from itd.request import endpoint
+
 if TYPE_CHECKING:
     from itd.client import Client
-from itd.base import api_wrapper
-from itd.enums import AuthLevel
 
 
-@api_wrapper()
-def get_portal(client: Client):
-    return client.request('get', 'v1/portal', level=AuthLevel.NO)
+@endpoint('get', 'v1/portal', level=AuthLevel.NO)
+def get_portal(client: Client): ...

--- a/itd/api/posts.py
+++ b/itd/api/posts.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from itd.base import api_wrapper
 from itd.enums import PostsTab, UserPostSorting
 from itd.exceptions import (
     AlreadyRepostedError,
@@ -18,12 +17,15 @@ from itd.exceptions import (
     ValidationError
 )
 from itd.poll import NewPoll
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper(
+@endpoint(
+    'post',
+    'posts',
     NotFoundError('Wall recipient'),
     ForbiddenError('post - some files not owned'),
     RequiresSubscriptionError('Video uploading'),
@@ -48,61 +50,61 @@ def create_post(
     if poll:
         data['poll'] = poll.poll.model_dump(mode='json')
 
-    return client.request('post', 'posts', data)
+    return data
 
 
-@api_wrapper(ValidationError())
+@endpoint('get', 'posts', ValidationError())
 def get_posts(client: Client, cursor: str | datetime | None = None, limit: int = 20, tab: PostsTab = PostsTab.POPULAR):
     data: dict = {'limit': limit, 'tab': tab.value}
     if cursor is not None:
         data['cursor'] = cursor
-    return client.request('get', 'posts', data)
+    return data
 
 
-@api_wrapper(NotFoundError('Post'))
-def get_post(client: Client, id: UUID):
-    return client.request('get', f'posts/{id}')
+@endpoint('get', 'posts/{id}', NotFoundError('Post'))
+def get_post(client: Client, id: UUID): ...
 
 
-@api_wrapper(NotFoundError('Post'), ForbiddenError('edit post'), EditExpiredError(), BannedWordError('Post'))
+@endpoint('put', 'posts/{id}', NotFoundError('Post'), ForbiddenError('edit post'), EditExpiredError(), BannedWordError('Post'))
 def edit_post(client: Client, id: UUID, content: str, spans: list[dict] = []):
-    return client.request('put', f'posts/{id}', {'content': content, 'spans': spans})
+    return {'content': content, 'spans': spans}
 
 
-@api_wrapper(NotFoundError('Post'), ForbiddenError('delete post'))
-def delete_post(client: Client, id: UUID):
-    return client.request('delete', f'posts/{id}')
+@endpoint('delete', 'posts/{id}', NotFoundError('Post'), ForbiddenError('delete post'))
+def delete_post(client: Client, id: UUID): ...
 
 
-@api_wrapper(NotFoundError('Post'), ForbiddenError('restore post'))
-def restore_post(client: Client, id: UUID):
-    return client.request('post', f'posts/{id}/restore')
+@endpoint('post', 'posts/{id}/restore', NotFoundError('Post'), ForbiddenError('restore post'))
+def restore_post(client: Client, id: UUID): ...
 
 
-@api_wrapper(NotFoundError('Post'), ForbiddenError('pin post'))
-def pin_post(client: Client, id: UUID):
-    return client.request('post', f'posts/{id}/pin')
+@endpoint('post', 'posts/{id}/pin', NotFoundError('Post'), ForbiddenError('pin post'))
+def pin_post(client: Client, id: UUID): ...
 
 
-@api_wrapper(NotPinnedError())
-def unpin_post(client: Client, id: UUID):
-    return client.request('delete', f'posts/{id}/pin')
+@endpoint('delete', 'posts/{id}/pin', NotPinnedError())
+def unpin_post(client: Client, id: UUID): ...
 
 
-@api_wrapper(NotFoundError('Post'), AlreadyRepostedError(), CantRepostYourselfError(), ValidationError(), BannedWordError('Post'))
+@endpoint('post', 'posts/{id}/repost', NotFoundError('Post'), AlreadyRepostedError(), CantRepostYourselfError(), ValidationError(), BannedWordError('Post'))
 def repost(client: Client, id: UUID, content: str | None = None):
     data = {}
     if content:
         data['content'] = content
-    return client.request('post', f'posts/{id}/repost', data)
+    return data
 
 
-@api_wrapper(ValidationError(), NotFoundError('User'))
+@endpoint('get', 'posts/user/{username_or_id}/liked', ValidationError(), NotFoundError('User'))
 def get_liked_posts(client: Client, username_or_id: str | UUID, cursor: datetime | None = None, limit: int = 20):
-    return client.request('get', f'posts/user/{username_or_id}/liked', {'limit': limit, 'cursor': cursor})
+    return {'limit': limit, 'cursor': cursor}
 
 
-@api_wrapper(ValidationError(), NotFoundError('User', res_check=lambda res: res.status_code == 404 and res.text == 'NOT_FOUND'))
+@endpoint(
+    'get',
+    'posts/user/{username_or_id}',
+    ValidationError(),
+    NotFoundError('User', res_check=lambda res: res.status_code == 404 and res.text == 'NOT_FOUND')
+)
 def get_user_posts(
     client: Client,
     username_or_id: str | UUID,
@@ -111,19 +113,17 @@ def get_user_posts(
     pinned_post_id: UUID | None = None,
     sort: UserPostSorting = UserPostSorting.NEW
 ):
-    return client.request('get', f'posts/user/{username_or_id}', {'limit': limit, 'cursor': cursor, 'pinnedPostId': pinned_post_id, 'sort': sort.value})
+    return {'limit': limit, 'cursor': cursor, 'pinnedPostId': pinned_post_id, 'sort': sort.value}
 
 
-@api_wrapper(NotFoundError('Post'))
-def like_post(client: Client, id: UUID):
-    return client.request('post', f'posts/{id}/like')
+@endpoint('post', 'posts/{id}/like', NotFoundError('Post'))
+def like_post(client: Client, id: UUID): ...
 
 
-@api_wrapper(NotFoundError('Post'))
-def unlike_post(client: Client, id: UUID):
-    return client.request('delete', f'posts/{id}/like')
+@endpoint('delete', 'posts/{id}/like', NotFoundError('Post'))
+def unlike_post(client: Client, id: UUID): ...
 
 
-@api_wrapper(ValidationError())
+@endpoint('post', 'posts/stats', ValidationError())
 def get_stats(client: Client, ids: list[UUID]):
-    return client.request('post', 'posts/stats', {'ids': [str(id) for id in ids]})  # if not found, will return empty list
+    return {'ids': [str(id) for id in ids]}  # if not found, will return empty list

--- a/itd/api/reports.py
+++ b/itd/api/reports.py
@@ -3,18 +3,20 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from itd.base import api_wrapper
 from itd.enums import ReportReason, ReportTargetType
 from itd.exceptions import AlreadyReportedError, NotFoundError, ValidationError
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper(
-    AlreadyReportedError(), NotFoundError('Report target', json_check=lambda json: 'не найден' in json.get('error', {}).get('message', '')), ValidationError()
+@endpoint(
+    'post',
+    'reports',
+    AlreadyReportedError(),
+    NotFoundError('Report target', json_check=lambda json: 'не найден' in json.get('error', {}).get('message', '')),
+    ValidationError()
 )
 def report(client: Client, id: UUID, type: ReportTargetType = ReportTargetType.POST, reason: ReportReason = ReportReason.OTHER, description: str | None = None):
-    if description is None:
-        description = ''
-    return client.request('post', 'reports', {'targetId': str(id), 'targetType': type.value, 'reason': reason.value, 'description': description})
+    return {'targetId': str(id), 'targetType': type.value, 'reason': reason.value, 'description': description or ''}

--- a/itd/api/search.py
+++ b/itd/api/search.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from itd.client import Client
-from itd.base import api_wrapper
 from itd.enums import AuthLevel
 from itd.exceptions import ValidationError
+from itd.request import endpoint
+
+if TYPE_CHECKING:
+    from itd.client import Client
 
 
-@api_wrapper(ValidationError())
+@endpoint('get', 'search', ValidationError(), level=AuthLevel.NO)
 def search(client: Client, query: str, user_limit: int = 5, hashtag_limit: int = 5):
-    return client.request('get', 'search', {'userLimit': user_limit, 'hashtagLimit': hashtag_limit, 'q': query}, level=AuthLevel.NO)
+    return {'userLimit': user_limit, 'hashtagLimit': hashtag_limit, 'q': query}

--- a/itd/api/sessions.py
+++ b/itd/api/sessions.py
@@ -3,21 +3,19 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from itd.request import endpoint
+
 if TYPE_CHECKING:
     from itd.client import Client
-from itd.base import api_wrapper
 
 
-@api_wrapper()
-def get_sessions(client: Client):
-    return client.request('get', 'v1/auth/sessions')
+@endpoint('get', 'v1/auth/sessions')
+def get_sessions(client: Client): ...
 
 
-@api_wrapper()
-def revoke(client: Client, id: UUID):
-    return client.request('delete', f'v1/auth/sessions/{id}')
+@endpoint('delete', 'v1/auth/sessions/{id}')
+def revoke(client: Client, id: UUID): ...
 
 
-@api_wrapper()
-def revoke_all(client: Client):
-    return client.request('delete', 'v1/auth/sessions')
+@endpoint('delete', 'v1/auth/sessions')
+def revoke_all(client: Client): ...

--- a/itd/api/subscription.py
+++ b/itd/api/subscription.py
@@ -2,43 +2,37 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from itd.base import api_wrapper
 from itd.exceptions import NotFoundError
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper()
-def get_subscription(client: Client):
-    return client.request('get', 'v1/subscription')
+@endpoint('get', 'v1/subscription')
+def get_subscription(client: Client): ...
 
 
-@api_wrapper()
-def pay_subscription(client: Client):
-    return client.request('post', 'v1/subscription/pay')
+@endpoint('post', 'v1/subscription/pay')
+def pay_subscription(client: Client): ...
 
 
-@api_wrapper(NotFoundError('Subsciption', json_check=lambda json: json.get('error') == 'Активная подписка не найдена'))
+@endpoint('post', 'v1/subscription/auto-renewal', NotFoundError('Subsciption', json_check=lambda json: json.get('error') == 'Активная подписка не найдена'))
 def toggle_subscription_auto_renewal(client: Client, enabled: bool):
-    return client.request('post', 'v1/subscription/auto-renewal', {'enabled': enabled})
+    return {'enabled': enabled}
 
 
-@api_wrapper()
-def bind_card(client: Client):
-    return client.request('post', 'v1/subscription/bind-card')
+@endpoint('post', 'v1/subscription/bind-card')
+def bind_card(client: Client): ...
 
 
-@api_wrapper()
-def get_payment_methods(client: Client):
-    return client.request('get', 'v1/subscription/methods')
+@endpoint('get', 'v1/subscription/methods')
+def get_payment_methods(client: Client): ...
 
 
-@api_wrapper()
-def set_default_payment_method(client: Client, method: str):
-    return client.request('post', f'/v1/subscription/methods/{method}/default')
+@endpoint('post', '/v1/subscription/methods/{method}/default')
+def set_default_payment_method(client: Client, method: str): ...
 
 
-@api_wrapper()
-def delete_payment_method(client: Client, method: str):
-    return client.request('delete', f'/v1/subscription/methods/{method}')
+@endpoint('delete', '/v1/subscription/methods/{method}')
+def delete_payment_method(client: Client, method: str): ...

--- a/itd/api/users.py
+++ b/itd/api/users.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from itd.base import api_wrapper
 from itd.enums import UNSET, AccessType, AuthLevel, Unset
 from itd.exceptions import (
     AlreadyBlockedError,
@@ -21,17 +20,17 @@ from itd.exceptions import (
     UsernameTakenError,
     ValidationError
 )
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper(NotFoundError('User'), TooLargeError('User'), NotFoundError('Profile'), TargetUserBannedError())
-def get_user(client: Client, username_or_id: str | UUID):
-    return client.request('get', f'users/{username_or_id}')
+@endpoint('get', 'users/{username_or_id}', NotFoundError('User'), TooLargeError('User'), NotFoundError('Profile'), TargetUserBannedError())
+def get_user(client: Client, username_or_id: str | UUID): ...
 
 
-@api_wrapper(ValidationError(), RequiresVerificationError('GIF banner uploading'), UsernameTakenError())
+@endpoint('put', 'users/me', ValidationError(), RequiresVerificationError('GIF banner uploading'), UsernameTakenError())
 def update_profile(client: Client, bio: str | None = None, display_name: str | None = None, username: str | None = None, banner_id: UUID | Unset | None = None):
     data = {}
     if bio is not None:
@@ -42,20 +41,18 @@ def update_profile(client: Client, bio: str | None = None, display_name: str | N
         data['username'] = username
     if banner_id is not None:
         data['bannerId'] = str(banner_id) if banner_id != UNSET else None
-    return client.request('put', 'users/me', data)
+    return data
 
 
-@api_wrapper()
-def get_profile(client: Client):
-    return client.request('get', 'profile', level=AuthLevel.NO)
+@endpoint('get', 'profile', level=AuthLevel.NO)
+def get_profile(client: Client): ...
 
 
-@api_wrapper()
-def get_privacy(client: Client):
-    return client.request('get', 'users/me/privacy')
+@endpoint('get', 'users/me/privacy')
+def get_privacy(client: Client): ...
 
 
-@api_wrapper(ValidationError())
+@endpoint('put', 'users/me/privacy', ValidationError())
 def update_privacy(
     client: Client,
     is_private: bool | None = None,
@@ -72,59 +69,70 @@ def update_privacy(
         data['likesVisibility'] = likes_visibility.value
     if show_last_seen is not None:
         data['showLastSeen'] = show_last_seen
-    return client.request('put', 'users/me/privacy', data)
+    return data
 
 
-@api_wrapper(NotFoundError('User'), AlreadyFollowingError(), TooLargeError('Username'), CantFollowYourselfError(), UserBlockedError(), TargetUserBannedError())
-def follow(client: Client, username_or_id: str | UUID):
-    return client.request('post', f'users/{username_or_id}/follow')
+@endpoint(
+    'post',
+    'users/{username_or_id}/follow',
+    NotFoundError('User'),
+    AlreadyFollowingError(),
+    TooLargeError('Username'),
+    CantFollowYourselfError(),
+    UserBlockedError(),
+    TargetUserBannedError()
+)
+def follow(client: Client, username_or_id: str | UUID): ...
 
 
-@api_wrapper(NotFoundError('User'), TooLargeError('Username'), TargetUserBannedError())
-def unfollow(client: Client, username_or_id: str | UUID):
-    return client.request('delete', f'users/{username_or_id}/follow')
+@endpoint('delete', 'users/{username_or_id}/follow', NotFoundError('User'), TooLargeError('Username'), TargetUserBannedError())
+def unfollow(client: Client, username_or_id: str | UUID): ...
 
 
-@api_wrapper(NotFoundError('User'), ValidationError(), TooLargeError('Username'), TargetUserBannedError())
+@endpoint('get', 'users/{username_or_id}/followers', NotFoundError('User'), ValidationError(), TooLargeError('Username'), TargetUserBannedError())
 def get_followers(client: Client, username_or_id: str | UUID, page: int = 1, limit: int = 20):  # !! page not works if not me
-    return client.request('get', f'users/{username_or_id}/followers', {'page': page, 'limit': limit})
+    return {'page': page, 'limit': limit}
 
 
-@api_wrapper(NotFoundError('User'), ValidationError(), TooLargeError('Username'), TargetUserBannedError())
+@endpoint('get', 'users/{username_or_id}/following', NotFoundError('User'), ValidationError(), TooLargeError('Username'), TargetUserBannedError())
 def get_following(client: Client, username_or_id: str | UUID, page: int = 1, limit: int = 20):  # !! page not works if not me
-    return client.request('get', f'users/{username_or_id}/following', {'page': page, 'limit': limit})
+    return {'page': page, 'limit': limit}
 
 
-@api_wrapper(AlreadyDeletedError('Account'))
-def delete_account(client: Client):
-    return client.request('delete', 'users/me')
+@endpoint('delete', 'users/me', AlreadyDeletedError('Account'))
+def delete_account(client: Client): ...
 
 
-@api_wrapper(NotDeletedError('Account'))
-def restore_account(client: Client):
-    return client.request('post', 'users/me/restore')
+@endpoint('post', 'users/me/restore', NotDeletedError('Account'))
+def restore_account(client: Client): ...
 
 
-@api_wrapper(NotFoundError('User'), TooLargeError('Username'), AlreadyBlockedError(), CantBlockYourselfError(), TargetUserBannedError())
-def block(client: Client, username_or_id: str | UUID):
-    return client.request('post', f'users/{username_or_id}/block')
+@endpoint(
+    'post',
+    'users/{username_or_id}/block',
+    NotFoundError('User'),
+    TooLargeError('Username'),
+    AlreadyBlockedError(),
+    CantBlockYourselfError(),
+    TargetUserBannedError()
+)
+def block(client: Client, username_or_id: str | UUID): ...
 
 
-@api_wrapper(NotFoundError('User'), TooLargeError('Username'), NotBlockedError(), TargetUserBannedError())
-def unblock(client: Client, username_or_id: str | UUID):
-    return client.request('delete', f'users/{username_or_id}/block')
+@endpoint('delete', 'users/{username_or_id}/block', NotFoundError('User'), TooLargeError('Username'), NotBlockedError(), TargetUserBannedError())
+def unblock(client: Client, username_or_id: str | UUID): ...
 
 
-@api_wrapper()
+@endpoint('get', 'users/me/blocked')
 def get_blocked(client: Client, page: int = 1, limit: int = 20):
-    return client.request('get', 'users/me/blocked', {'limit': limit, 'page': page})
+    return {'limit': limit, 'page': page}
 
 
-@api_wrapper()
+@endpoint('post', 'users/follow-status')
 def get_follow_status(client: Client, user_ids: list[UUID]):
-    return client.request('post', 'users/follow-status', {'userIds': list(map(str, user_ids))})
+    return {'userIds': list(map(str, user_ids))}
 
 
-@api_wrapper()
+@endpoint('get', 'users/search')
 def search_users(client: Client, query: str, limit: int = 10):
-    return client.request('get', 'users/search', {'q': query, 'limit': limit})
+    return {'q': query, 'limit': limit}

--- a/itd/api/verification.py
+++ b/itd/api/verification.py
@@ -2,18 +2,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from itd.base import api_wrapper
+from itd.request import endpoint
 
 if TYPE_CHECKING:
     from itd.client import Client
 
 
-@api_wrapper()
+# {"success":true,"request":{"id":"fc54e54f-8586-4d8c-809e-df93161f99da","userId":"9096a85b-c319-483e-8940-6921be427ad0","videoUrl":"https://943701f000610900cbe86b72234e451d.bckt.ru/videos/354f28a6-9ac7-48a6-879a-a454062b1d6b.mp4","status":"pending","rejectionReason":null,"reviewedBy":null,"reviewedAt":null,"createdAt":"2026-01-30T12:58:14.228Z","updatedAt":"2026-01-30T12:58:14.228Z"}}
+@endpoint('post', 'verification/submit')
 def verify(client: Client, file_url: str):
-    # {"success":true,"request":{"id":"fc54e54f-8586-4d8c-809e-df93161f99da","userId":"9096a85b-c319-483e-8940-6921be427ad0","videoUrl":"https://943701f000610900cbe86b72234e451d.bckt.ru/videos/354f28a6-9ac7-48a6-879a-a454062b1d6b.mp4","status":"pending","rejectionReason":null,"reviewedBy":null,"reviewedAt":null,"createdAt":"2026-01-30T12:58:14.228Z","updatedAt":"2026-01-30T12:58:14.228Z"}}
-    return client.request('post', 'verification/submit', {'videoUrl': file_url})
+    return {'videoUrl': file_url}
 
 
-@api_wrapper()
-def get_verification_status(client: Client):
-    return client.request('get', 'verification/status')
+@endpoint('get', 'verification/status')
+def get_verification_status(client: Client): ...

--- a/itd/base.py
+++ b/itd/base.py
@@ -48,7 +48,8 @@ class ITDBaseModel:
     def __init__(self, client: Client | None = None) -> None:
         self._client = client or get_default_client()
 
-        self._loaded_attrs: set[str] = set()
+        if '_loaded_attrs' not in self.__dict__:  # model could set attributes before calling super().__init__() (eg User sets username)
+            self._loaded_attrs: set[str] = set()
         self._extra_context = {}
 
     def _init_refresh(self):
@@ -58,8 +59,9 @@ class ITDBaseModel:
     def __setattr__(self, name: str, value: Any) -> None:
         if isinstance(value, ITDBaseModel) and (client := _getattr(self, '_client')):  # ai
             value._client = client
-        if '_loaded_attrs' in self.__dict__:
-            self._loaded_attrs.add(name)
+        if '_loaded_attrs' not in self.__dict__:  # attribute is set before __init__, remember it anyway - otherwise getattr will refresh loaded value
+            object.__setattr__(self, '_loaded_attrs', set())
+        self._loaded_attrs.add(name)
         object.__setattr__(self, name, value)
 
     def _post_refresh(self): ...

--- a/itd/base.py
+++ b/itd/base.py
@@ -1,29 +1,16 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from datetime import datetime
-from functools import wraps
-from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, Iterator, SupportsIndex, TypeVar, cast, overload
 from uuid import UUID
 
 from pydantic import BaseModel
 from pydantic.fields import FieldInfo
-from requests import Response
-from requests.exceptions import JSONDecodeError
 
-from itd._default import get_config, get_default_client, limiters, limits
-from itd.enums import ALL, BATCH, All, Batch, DebugResponseMode, LoadStatus
-from itd.exceptions import (
-    DEFAULT_ERRORS,
-    AccessTokenExpiredError,
-    AccountDeletedError,
-    InvalidAccessTokenError,
-    ITDException,
-    RateLimitError,
-    ValidationError
-)
+from itd._default import get_default_client
+from itd.enums import ALL, BATCH, All, Batch, LoadStatus
 from itd.logger import get_logger
+from itd.request import api_wrapper, catch_errors, rate_limit  # noqa: F401 # moved to itd.request, reexported for backwards compatibility
 
 if TYPE_CHECKING:
     from itd.client import Client
@@ -349,166 +336,3 @@ class ITDList(ITDBaseModel, list[T]):
         super().clear()
         self.cursor = None
         self.has_more = True
-
-
-def _filter_bytes(args: tuple):
-    filtered = []
-    for arg in args:
-        if isinstance(arg, bytes):
-            filtered.append('_bytecode_')
-        else:
-            filtered.append(arg)
-    return filtered
-
-
-# user calls `Me` -> model calls `get_me` -> `api_wrapper` wrapper: (`get_me` -> `client.request` -> `fetch` -> responses 401 -> `refresh_auth` from `api_wrapper` -> `client.resuest` -> `fetch` -> token refreshed -> `api_wrapper` backs to main query -> `get_me` -> `client.request` -> `fetch` -> user fetched) -> model recieves data -> pydantic fills model
-def api_wrapper(*exceptions: ITDException):
-    """Декоратор для отлавливания ошибок
-
-    Args:
-        *exceptions (ITDException): Список ошибок для отлавливания
-    """
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(client: Client, *args, **kwargs) -> Response | None:
-            name = func.__name__
-            reauthed = False
-
-            def exec():
-                nonlocal reauthed
-                l.info('exec %s %s %s', func.__name__, _filter_bytes(args), kwargs)
-
-                config = get_config()
-                is_first = True
-                if name in limits and limits[name] in limiters:
-                    limiter = limiters[limits[name]]
-                    if config.auto_acquire:
-                        limiter.acquire()
-                    is_first = not limiter.used
-                    limiter.request()
-
-                ip_limiter = config.ip_limiter
-                if ip_limiter:
-                    ip_limiter.acquire()
-
-                res: Response = func(client, *args, **kwargs)
-
-                assert isinstance(res, Response)
-                if res.status_code == 204:
-                    if client.config.debug_response != DebugResponseMode.NO:
-                        l.debug('no response')
-                    return res
-
-                remaining = int(res.headers.get('x-ratelimit-remaining', 0))
-                limit = int(res.headers.get('x-ratelimit-limit', 0))
-                limits[name] = limit
-
-                if limit not in limiters and config.limiter is not None:
-                    limiters[limit] = config.limiter(limit)
-
-                if limit in limiters and (config.auto_acquire or is_first):
-                    limiters[limit].sync(remaining)
-
-                if client.config.debug_response == DebugResponseMode.BEFORE:
-                    l.debug('response (raw): %s', res.text)
-
-                try:
-                    json = res.json()
-                except JSONDecodeError:
-                    json = {}
-                    l.warning('failed to parse json: %s', res.text[:1000])
-
-                for exception in DEFAULT_ERRORS + exceptions:
-                    if (
-                        (exception.res_check and exception.res_check(res))
-                        or (exception.text_check and exception.text_check(res.text))
-                        or (exception.json_check and exception.json_check(json))
-                        or exception.status_code is not None
-                        and res.status_code == exception.status_code
-                        or isinstance(json.get('error'), dict)
-                        and (
-                            exception.code is not None
-                            and json['error'].get('code') == exception.code
-                            or exception.message is not None
-                            and json['error'].get('message') == exception.message
-                        )
-                    ):
-                        if isinstance(exception, ValidationError):
-                            exception.text = json.get('error', {}).get('message', 'Failed validation')
-
-                        if isinstance(exception, RateLimitError) and isinstance(json.get('error'), dict):
-                            exception.retry_after = json.get('error', {}).get('retryAfter', 0)
-
-                        # token is checked before the request, but server still can reject it (clock skew, revoked session,
-                        # token expired while request was in flight) - refresh and repeat the request once, before callbacks and before raising
-                        if (
-                            isinstance(exception, (AccessTokenExpiredError, InvalidAccessTokenError))
-                            and not reauthed
-                            and name != 'refresh_token'
-                            and client.can_refresh_auth
-                        ):
-                            reauthed = True
-                            if not client.is_token_expired(margin=0):
-                                l.warning(
-                                    'server rejected access_token that is not expired by local clock (expires at %s, now is %s): '
-                                    'check system time (clock skew) or session was revoked',
-                                    client.access_token_data.expired_at if client.access_token_data else None,
-                                    datetime.now()
-                                )
-                            l.warning('%s on %s: refresh access_token and retry', exception.__class__.__name__, name)
-                            client.refresh_auth(force=True)
-                            return exec()
-
-                        if isinstance(exception, AccountDeletedError):
-                            exception.can_restore = json.get('error', {}).get('canRestore', True)
-
-                        client._process_exc_callbacks(exception)
-                        raise exception
-
-                if client.config.debug_response == DebugResponseMode.AFTER:
-                    l.debug('response: %s', json)
-                if client.config.debug_response == DebugResponseMode.KEYS:
-                    if 'data' in json:
-                        l.debug('response keys: data - %s', list(json['data'].keys()))
-                    else:
-                        l.debug('response keys: %s', list(json.keys()))
-                res.raise_for_status()
-                return res
-
-            if not client.config._retry_enabled:
-                return exec()
-
-            while True:
-                try:
-                    return exec()
-                except client.config._retry_exceptions as e:
-                    if getattr(e, 'retry_after', 0) > client.config.retry_max_retry_after:
-                        l.error('too large rate limit')
-                        raise
-
-                    retry_after = getattr(e, 'retry_after', 0) or client.config.retry_delay
-                    l.warning('%s on %s: wait %ss', e.__class__.__name__, func.__name__, retry_after)
-                    sleep(retry_after)
-                    if name in limits and limits[name] in limiters:
-                        limiters[limits[name]].on_limit()
-
-        return wrapper
-
-    return decorator
-
-
-catch_errors = api_wrapper
-
-
-def rate_limit():
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(client: Client, *args, **kwargs) -> Response | None:
-            l.warning('base.rate_limit is deprecated and will be removed in 2.7.0.')
-            return func(client, *args, **kwargs)
-
-        return wrapper
-
-    return decorator

--- a/itd/base.py
+++ b/itd/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from datetime import datetime
 from functools import wraps
 from time import sleep
 from typing import TYPE_CHECKING, Any, Callable, Iterator, SupportsIndex, TypeVar, cast, overload
@@ -439,8 +440,8 @@ def api_wrapper(*exceptions: ITDException):
                         if isinstance(exception, RateLimitError) and isinstance(json.get('error'), dict):
                             exception.retry_after = json.get('error', {}).get('retryAfter', 0)
 
-                        # токен проверяется перед запросом, но сервер все равно может его отвергнуть (расхождение часов, отозванная сессия,
-                        # токен протух пока запрос шел) - обновляем и повторяем запрос один раз, до колбэков и до выброса ошибки
+                        # token is checked before the request, but server still can reject it (clock skew, revoked session,
+                        # token expired while request was in flight) - refresh and repeat the request once, before callbacks and before raising
                         if (
                             isinstance(exception, (AccessTokenExpiredError, InvalidAccessTokenError))
                             and not reauthed
@@ -448,6 +449,13 @@ def api_wrapper(*exceptions: ITDException):
                             and client.can_refresh_auth
                         ):
                             reauthed = True
+                            if not client.is_token_expired(margin=0):
+                                l.warning(
+                                    'server rejected access_token that is not expired by local clock (expires at %s, now is %s): '
+                                    'check system time (clock skew) or session was revoked',
+                                    client.access_token_data.expired_at if client.access_token_data else None,
+                                    datetime.now()
+                                )
                             l.warning('%s on %s: refresh access_token and retry', exception.__class__.__name__, name)
                             client.refresh_auth(force=True)
                             return exec()

--- a/itd/base.py
+++ b/itd/base.py
@@ -10,7 +10,6 @@ from pydantic.fields import FieldInfo
 from itd._default import get_default_client
 from itd.enums import ALL, BATCH, All, Batch, LoadStatus
 from itd.logger import get_logger
-from itd.request import api_wrapper, catch_errors, rate_limit  # noqa: F401 # moved to itd.request, reexported for backwards compatibility
 
 if TYPE_CHECKING:
     from itd.client import Client

--- a/itd/base.py
+++ b/itd/base.py
@@ -13,7 +13,15 @@ from requests.exceptions import JSONDecodeError
 
 from itd._default import get_config, get_default_client, limiters, limits
 from itd.enums import ALL, BATCH, All, Batch, DebugResponseMode, LoadStatus
-from itd.exceptions import DEFAULT_ERRORS, AccountDeletedError, ITDException, RateLimitError, ValidationError
+from itd.exceptions import (
+    DEFAULT_ERRORS,
+    AccessTokenExpiredError,
+    AccountDeletedError,
+    InvalidAccessTokenError,
+    ITDException,
+    RateLimitError,
+    ValidationError
+)
 from itd.logger import get_logger
 
 if TYPE_CHECKING:
@@ -364,8 +372,10 @@ def api_wrapper(*exceptions: ITDException):
         @wraps(func)
         def wrapper(client: Client, *args, **kwargs) -> Response | None:
             name = func.__name__
+            reauthed = False
 
             def exec():
+                nonlocal reauthed
                 l.info('exec %s %s %s', func.__name__, _filter_bytes(args), kwargs)
 
                 config = get_config()
@@ -429,10 +439,18 @@ def api_wrapper(*exceptions: ITDException):
                         if isinstance(exception, RateLimitError) and isinstance(json.get('error'), dict):
                             exception.retry_after = json.get('error', {}).get('retryAfter', 0)
 
-                        # now checks token before request
-                        # if isinstance(exception, (UnauthorizedError, AccessTokenExpiredError)) and client.refresh_token:
-                        #     client.refresh_auth()
-                        #     return wrapper(client, *args, **kwargs)
+                        # токен проверяется перед запросом, но сервер все равно может его отвергнуть (расхождение часов, отозванная сессия,
+                        # токен протух пока запрос шел) - обновляем и повторяем запрос один раз, до колбэков и до выброса ошибки
+                        if (
+                            isinstance(exception, (AccessTokenExpiredError, InvalidAccessTokenError))
+                            and not reauthed
+                            and name != 'refresh_token'
+                            and client.can_refresh_auth
+                        ):
+                            reauthed = True
+                            l.warning('%s on %s: refresh access_token and retry', exception.__class__.__name__, name)
+                            client.refresh_auth(force=True)
+                            return exec()
 
                         if isinstance(exception, AccountDeletedError):
                             exception.can_restore = json.get('error', {}).get('canRestore', True)

--- a/itd/client.py
+++ b/itd/client.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from functools import cached_property
 from os import getenv
-from threading import Thread
+from threading import RLock, Thread
 from time import sleep
 from typing import Callable, Literal, overload
 from uuid import UUID
@@ -146,6 +146,7 @@ class Config:
     on_exceptions: dict[type[Exception], Callable[[Exception], None]] = field(default_factory=dict)
     batch_sizes: BatchSizes = field(default_factory=BatchSizes)
     refresh_token_cookie_name: str = 'refresh_token'
+    token_expiry_margin: float = 60  # за сколько секунд до истечения access token считается протухшим (запас на сеть и расхождение часов)
 
     def __post_init__(self):
         match self.user_agent:
@@ -231,6 +232,7 @@ class Client:
         self._visible_posts_buffer: list[Post] = []
         self.last_active = datetime.now()
         self._credfile: Credfile | None = None
+        self._refresh_lock = RLock()  # чтобы фоновые таймеры и основной поток не обновляли токен одновременно
 
         self.session = Session()
         adapter = HTTPAdapter(pool_connections=1, pool_maxsize=10, pool_block=False)  # idk what is this, (claude added) just for better stability
@@ -304,42 +306,71 @@ class Client:
         self._credfile.valid = valid
         self._credfile.flush()
 
+    def is_token_expired(self, margin: float | None = None) -> bool:
+        """Истёк ли (или вот-вот истечет) access token
+
+        Args:
+            margin (float | None, optional): Запас в секундах (None - config.token_expiry_margin). Defaults to None.
+
+        Returns:
+            bool: Истёк ли токен (True если токена нет вообще)
+        """
+        if self.access_token is None:
+            return True
+        if self.access_token_data is None:  # не смогли распарсить jwt - считаем валидным, решать серверу
+            return False
+
+        margin = self.config.token_expiry_margin if margin is None else margin
+        return self.access_token_data.expired_at - timedelta(seconds=margin) <= datetime.now()
+
+    @property
+    def can_refresh_auth(self) -> bool:
+        """Есть ли refresh token, чтобы обновить access token"""
+        return self.refresh_token is not None or self.auth_level >= AuthLevel.REFRESH
+
     def refresh_auth(self, force: bool = False) -> str:
         """Обновить access token
+
+        Args:
+            force (bool, optional): Обновить, даже если текущий токен еще валиден. Defaults to False.
 
         Returns:
             str: Токен
         """
 
-        l.debug('refresh access_token')
-        if not force and self._credfile and self._credfile.update():
-            self.token = self._credfile.access
-            self.refresh_token = self._credfile.refresh
+        with self._refresh_lock:
+            if not force and not self.is_token_expired():  # обновлен другим потоком, пока ждали лок
+                l.debug('access_token is already fresh')
+                return self.token
 
-            if self.access_token:
-                assert self.access_token_data
-                if self.access_token_data.expired_at > datetime.now():
-                    l.debug('update access_token from credfile')
-                    return self.access_token
+            l.debug('refresh access_token')
+            if not force and self._credfile and self._credfile.update():
+                self.token = self._credfile.access
+                self.refresh_token = self._credfile.refresh
+
+                if self.access_token:
+                    if not self.is_token_expired():
+                        l.debug('update access_token from credfile')
+                        return self.access_token
+                    else:
+                        l.info('credfile access_token expired')
                 else:
-                    l.info('credfile access_token expired')
-            else:
-                l.info('crefile access_token is none')
+                    l.info('crefile access_token is none')
 
-        try:
-            res = refresh_token(self)
-        except (SessionExpiredError, SessionNotFoundError, SessionRevokedError):
-            if force:
+            try:
+                res = refresh_token(self)
+            except (SessionExpiredError, SessionNotFoundError, SessionRevokedError):
+                if force:
+                    raise
+                self._update_file(valid=False)
                 raise
-            self._update_file(valid=False)
-            raise
 
-        self.token = res.json().get('accessToken') or res.json()['token']
-        if 'refresh_token' in res.cookies:
-            self.refresh_token = res.cookies['refresh_token']
-        self._update_file()
+            self.token = res.json().get('accessToken') or res.json()['token']
+            if 'refresh_token' in res.cookies:
+                self.refresh_token = res.cookies['refresh_token']
+            self._update_file()
 
-        return self.token
+            return self.token
 
     def _start_check_active_timer(self):
         l.debug('start check active timer')
@@ -409,19 +440,22 @@ class Client:
         if level > self.auth_level and not self.config.bypass_auth_level:
             raise InsufficientAuthLevelError(self.auth_level, level)
 
-        if (
-            level >= AuthLevel.ACCESS
-            and (self.access_token is None or (self.access_token_data and self.access_token_data.expired_at - timedelta(minutes=1) <= datetime.now()))
-            and url != 'v1/auth/refresh'
-        ):
-            self.refresh_auth()
+        send_token = True
+        # access token подставляется в любой запрос (в тч в эндпоинты с AuthLevel.NO), поэтому и обновлять его нужно вне зависимости от level:
+        # иначе после истечения токена такие запросы навсегда падают с AccessTokenExpiredError
+        if url != 'v1/auth/refresh' and self.is_token_expired():
+            if level >= AuthLevel.ACCESS or self.can_refresh_auth:
+                self.refresh_auth()
+            elif self.access_token is not None:
+                l.warning('access_token expired and cannot be refreshed, send %s %s without authorization', method.upper(), url)
+                send_token = False
 
-        return fetch(self, method, url, params, files)
+        return fetch(self, method, url, params, files, send_token=send_token)
 
     def request_sse(self, url: str):
         l.debug('sse %s', url)
 
-        if self.access_token is None or (self.access_token_data and self.access_token_data.expired_at - timedelta(minutes=1) <= datetime.now()):
+        if self.is_token_expired():
             self.refresh_auth()
 
         return fetch_stream(self, url)

--- a/itd/client.py
+++ b/itd/client.py
@@ -22,7 +22,6 @@ from itd.api.posts import get_stats
 from itd.api.search import search
 from itd.enums import BATCH, All, AuthLevel, Batch, DebugResponseMode, ParseMode, Role, UserAgent, ViewReason
 from itd.exceptions import (
-    AccessTokenExpiredError,
     InsufficientAuthLevelError,
     NotFoundError,
     RateLimitError,

--- a/itd/client.py
+++ b/itd/client.py
@@ -146,7 +146,7 @@ class Config:
     on_exceptions: dict[type[Exception], Callable[[Exception], None]] = field(default_factory=dict)
     batch_sizes: BatchSizes = field(default_factory=BatchSizes)
     refresh_token_cookie_name: str = 'refresh_token'
-    token_expiry_margin: float = 60  # за сколько секунд до истечения access token считается протухшим (запас на сеть и расхождение часов)
+    token_expiry_margin: float = 60  # how many seconds before expiration access token is considered expired (margin for network and clock skew)
 
     def __post_init__(self):
         match self.user_agent:
@@ -232,7 +232,7 @@ class Client:
         self._visible_posts_buffer: list[Post] = []
         self.last_active = datetime.now()
         self._credfile: Credfile | None = None
-        self._refresh_lock = RLock()  # чтобы фоновые таймеры и основной поток не обновляли токен одновременно
+        self._refresh_lock = RLock()  # so background timers and main thread dont refresh token simultaneously
 
         self.session = Session()
         adapter = HTTPAdapter(pool_connections=1, pool_maxsize=10, pool_block=False)  # idk what is this, (claude added) just for better stability
@@ -317,7 +317,7 @@ class Client:
         """
         if self.access_token is None:
             return True
-        if self.access_token_data is None:  # не смогли распарсить jwt - считаем валидным, решать серверу
+        if self.access_token_data is None:  # failed to parse jwt - assume valid, let server decide
             return False
 
         margin = self.config.token_expiry_margin if margin is None else margin
@@ -339,7 +339,7 @@ class Client:
         """
 
         with self._refresh_lock:
-            if not force and not self.is_token_expired():  # обновлен другим потоком, пока ждали лок
+            if not force and not self.is_token_expired():  # refreshed by another thread while we were waiting for the lock
                 l.debug('access_token is already fresh')
                 return self.token
 
@@ -441,8 +441,8 @@ class Client:
             raise InsufficientAuthLevelError(self.auth_level, level)
 
         send_token = True
-        # access token подставляется в любой запрос (в тч в эндпоинты с AuthLevel.NO), поэтому и обновлять его нужно вне зависимости от level:
-        # иначе после истечения токена такие запросы навсегда падают с AccessTokenExpiredError
+        # access token is attached to every request (including AuthLevel.NO endpoints), so it must be refreshed regardless of level:
+        # otherwise such requests fail with AccessTokenExpiredError forever once the token expires
         if url != 'v1/auth/refresh' and self.is_token_expired():
             if level >= AuthLevel.ACCESS or self.can_refresh_auth:
                 self.refresh_auth()

--- a/itd/exceptions.py
+++ b/itd/exceptions.py
@@ -18,6 +18,48 @@ class ITDException(Exception):
     def __str__(self) -> str:
         return self.text
 
+    # instances listed in DEFAULT_ERRORS and passed to @endpoint are declarations: they only describe how to recognize the error.
+    # matches() recognizes it in the response, prepare() builds the exception to raise
+    def matches(self, res: Response, json: dict) -> bool:
+        """Похож ли ответ на эту ошибку
+
+        Args:
+            res (Response): Ответ
+            json (dict): Тело ответа
+
+        Returns:
+            bool: Совпадение
+        """
+        error = json.get('error') if isinstance(json.get('error'), dict) else {}
+        return bool(
+            (self.res_check and self.res_check(res))
+            or (self.text_check and self.text_check(res.text))
+            or (self.json_check and self.json_check(json))
+            or (self.status_code is not None and res.status_code == self.status_code)
+            or (self.code is not None and error.get('code') == self.code)
+            or (self.message is not None and error.get('message') == self.message)
+        )
+
+    def prepare(self, json: dict) -> 'ITDException':
+        """Собрать ошибку для выброса - копию декларации, дополненную данными из ответа
+
+        Args:
+            json (dict): Тело ответа
+
+        Returns:
+            ITDException: Ошибка
+        """
+        # именно копию: декларации переиспользуются между запросами и потоками, мутировать их нельзя.
+        # __init__ не вызываем - у наследников он с разными аргументами (NotFoundError('Post') и тд)
+        exception = self.__class__.__new__(self.__class__)
+        BaseException.__init__(exception, *self.args)
+        exception.__dict__.update(self.__dict__)
+        exception._fill(json.get('error') if isinstance(json.get('error'), dict) else {})
+        return exception
+
+    def _fill(self, error: dict) -> None:
+        """Дополнить ошибку данными из ['error'] (пустой dict если там не объект)"""
+
 
 class ValidateError(ITDException):
     pass
@@ -29,6 +71,9 @@ class ValidationError(ValidateError):
     status_code = 422
     json_check = staticmethod(lambda json: 'found' in json)
 
+    def _fill(self, error: dict) -> None:
+        self.text = error.get('message', 'Failed validation')
+
 
 class RateLimitError(ITDException):
     code = 'RATE_LIMIT_EXCEEDED'
@@ -36,6 +81,9 @@ class RateLimitError(ITDException):
 
     def __init__(self, retry_after: int = 0):
         self.retry_after = retry_after
+
+    def _fill(self, error: dict) -> None:
+        self.retry_after = error.get('retryAfter', 0)
 
     def __str__(self) -> str:
         if self.retry_after:
@@ -344,6 +392,9 @@ class AccountDeletedError(ITDException):
     text = 'Account has been deleted'
     can_restore: bool = True
     restore_deadline: datetime | None = None
+
+    def _fill(self, error: dict) -> None:
+        self.can_restore = error.get('canRestore', True)
 
 
 DEFAULT_ERRORS = (

--- a/itd/request.py
+++ b/itd/request.py
@@ -14,7 +14,7 @@ from requests.exceptions import JSONDecodeError
 
 from itd._default import get_config, limiters, limits
 from itd.enums import AuthLevel, DebugResponseMode
-from itd.exceptions import DEFAULT_ERRORS, AccessTokenExpiredError, ITDException, InvalidAccessTokenError
+from itd.exceptions import DEFAULT_ERRORS, AccessTokenExpiredError, InvalidAccessTokenError, ITDException
 from itd.logger import get_logger
 
 if TYPE_CHECKING:
@@ -73,7 +73,7 @@ def decode_jwt_payload(jwt_token: str) -> dict[str, Any]:
     """
     parts = jwt_token.split('.')
     if len(parts) != 3:
-        raise ValueError("Not enough parts in access token")
+        raise ValueError('Not enough parts in access token')
     payload = parts[1]
     payload += '=' * ((4 - len(payload) % 4) % 4)
     decoded = urlsafe_b64decode(payload).decode('utf-8')
@@ -95,14 +95,9 @@ def is_token_expired(access_token: str) -> bool:
 
 
 def fetch(
-    client: 'Client',
-    method: str,
-    url: str,
-    params: dict = {},
-    files: dict[str, tuple[str, BufferedReader | bytes]] = {},
-    send_token: bool = True
+    client: 'Client', method: str, url: str, params: dict = {}, files: dict[str, tuple[str, BufferedReader | bytes]] = {}, send_token: bool = True
 ) -> Response:
-    headers = {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "Accept-Language": "ru-RU,ru;q=0.8,en-US;q=0.5,en;q=0.3"}
+    headers = {'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8', 'Accept-Language': 'ru-RU,ru;q=0.8,en-US;q=0.5,en;q=0.3'}
     if client.config._user_agent:
         headers['User-Agent'] = client.config._user_agent
     if client.access_token and send_token:
@@ -111,7 +106,7 @@ def fetch(
     # ai begin ---
     def _do_request():
         m = method.lower()
-        if m == "get":
+        if m == 'get':
             return client.session.get(f'{client.config.url}/{url}', timeout=client.config._timeout, params=params, headers=headers)
 
         return client.session.request(
@@ -141,9 +136,9 @@ def fetch_stream(client: 'Client', url: str):
     """Fetch для SSE streaming запросов"""
     base = f'https://xn--d1ah4a.com/api/{url}'
     headers = {
-        "Accept": "text/event-stream",
-        "Authorization": 'Bearer ' + client.token,
-        "Cache-Control": "no-cache",
+        'Accept': 'text/event-stream',
+        'Authorization': 'Bearer ' + client.token,
+        'Cache-Control': 'no-cache',
         'Sec-WebSocket-Extensions': 'permessage-deflate',
         'Sec-WebSocket-Key': '3tMaiXFWtq34tenKN/+T4Q==',
         'Sec-WebSocket-Version': '13'
@@ -301,9 +296,6 @@ def api_wrapper(*exceptions: ITDException):
     return decorator
 
 
-catch_errors = api_wrapper
-
-
 @dataclass
 class Endpoint:
     """Описание эндпоинта, доступно как атрибут `.endpoint` у декорированной функции"""
@@ -345,19 +337,6 @@ def endpoint(method: str, url: str, *exceptions: ITDException, level: AuthLevel 
 
         wrapper = api_wrapper(*exceptions)(request)
         wrapper.endpoint = Endpoint(method, url, level, exceptions)
-        return wrapper
-
-    return decorator
-
-
-def rate_limit():
-
-    def decorator(func):
-        @wraps(func)
-        def wrapper(client: 'Client', *args, **kwargs) -> Response | None:
-            l.warning('rate_limit is deprecated and will be removed in 2.7.0.')
-            return func(client, *args, **kwargs)
-
         return wrapper
 
     return decorator

--- a/itd/request.py
+++ b/itd/request.py
@@ -86,11 +86,18 @@ def is_token_expired(access_token: str) -> bool:
     return time() - 1 >= payload['exp']
 
 
-def fetch(client: 'Client', method: str, url: str, params: dict = {}, files: dict[str, tuple[str, BufferedReader | bytes]] = {}) -> Response:
+def fetch(
+    client: 'Client',
+    method: str,
+    url: str,
+    params: dict = {},
+    files: dict[str, tuple[str, BufferedReader | bytes]] = {},
+    send_token: bool = True
+) -> Response:
     headers = {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "Accept-Language": "ru-RU,ru;q=0.8,en-US;q=0.5,en;q=0.3"}
     if client.config._user_agent:
         headers['User-Agent'] = client.config._user_agent
-    if client.access_token:
+    if client.access_token and send_token:
         headers['Authorization'] = 'Bearer ' + client.access_token
 
     # ai begin ---

--- a/itd/request.py
+++ b/itd/request.py
@@ -1,12 +1,20 @@
 from _io import BufferedReader
 from base64 import urlsafe_b64decode
+from dataclasses import dataclass, field
+from datetime import datetime
+from functools import wraps
+from inspect import signature
 from json import loads
-from time import time
-from typing import TYPE_CHECKING, Any
+from time import sleep, time
+from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import quote
 
 from requests import Response, Session
+from requests.exceptions import JSONDecodeError
 
+from itd._default import get_config, limiters, limits
+from itd.enums import AuthLevel, DebugResponseMode
+from itd.exceptions import DEFAULT_ERRORS, AccessTokenExpiredError, ITDException, InvalidAccessTokenError
 from itd.logger import get_logger
 
 if TYPE_CHECKING:
@@ -141,3 +149,215 @@ def fetch_stream(client: 'Client', url: str):
         'Sec-WebSocket-Version': '13'
     }
     return client.session.get(base, headers=headers, stream=True, timeout=None)
+
+
+@dataclass
+class Payload:
+    """Тело запроса эндпоинта: параметры и файлы"""
+
+    params: dict = field(default_factory=dict)
+    files: dict[str, tuple[str, BufferedReader | bytes]] = field(default_factory=dict)
+
+
+def _filter_bytes(args: tuple):
+    filtered = []
+    for arg in args:
+        if isinstance(arg, bytes):
+            filtered.append('_bytecode_')
+        else:
+            filtered.append(arg)
+    return filtered
+
+
+def _find_error(res: Response, json: dict, exceptions: tuple[ITDException, ...]) -> ITDException | None:
+    """Найти ошибку, под которую подходит ответ
+
+    Args:
+        res (Response): Ответ
+        json (dict): Тело ответа
+        exceptions (tuple[ITDException, ...]): Ошибки эндпоинта (проверяются после общих)
+
+    Returns:
+        ITDException | None: Ошибка (None если ответ успешный)
+    """
+    for declaration in DEFAULT_ERRORS + exceptions:
+        if declaration.matches(res, json):
+            return declaration.prepare(json)
+    return None
+
+
+# user calls `Me` -> model calls `get_me` -> `api_wrapper` wrapper: (`get_me` -> `client.request` -> `fetch` -> responses 401 -> `refresh_auth` from `api_wrapper` -> `client.resuest` -> `fetch` -> token refreshed -> `api_wrapper` backs to main query -> `get_me` -> `client.request` -> `fetch` -> user fetched) -> model recieves data -> pydantic fills model
+def api_wrapper(*exceptions: ITDException):
+    """Декоратор для отлавливания ошибок
+
+    Args:
+        *exceptions (ITDException): Список ошибок для отлавливания
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(client: 'Client', *args, **kwargs) -> Response | None:
+            name = func.__name__
+            reauthed = False
+
+            def exec():
+                nonlocal reauthed
+                l.info('exec %s %s %s', name, _filter_bytes(args), kwargs)
+
+                config = get_config()
+                is_first = True
+                if name in limits and limits[name] in limiters:
+                    limiter = limiters[limits[name]]
+                    if config.auto_acquire:
+                        limiter.acquire()
+                    is_first = not limiter.used
+                    limiter.request()
+
+                ip_limiter = config.ip_limiter
+                if ip_limiter:
+                    ip_limiter.acquire()
+
+                res: Response = func(client, *args, **kwargs)
+
+                assert isinstance(res, Response)
+                if res.status_code == 204:
+                    if client.config.debug_response != DebugResponseMode.NO:
+                        l.debug('no response')
+                    return res
+
+                remaining = int(res.headers.get('x-ratelimit-remaining', 0))
+                limit = int(res.headers.get('x-ratelimit-limit', 0))
+                limits[name] = limit
+
+                if limit not in limiters and config.limiter is not None:
+                    limiters[limit] = config.limiter(limit)
+
+                if limit in limiters and (config.auto_acquire or is_first):
+                    limiters[limit].sync(remaining)
+
+                if client.config.debug_response == DebugResponseMode.BEFORE:
+                    l.debug('response (raw): %s', res.text)
+
+                try:
+                    json = res.json()
+                except JSONDecodeError:
+                    json = {}
+                    l.warning('failed to parse json: %s', res.text[:1000])
+
+                exception = _find_error(res, json, exceptions)
+                if exception is not None:
+                    # token is checked before the request, but server still can reject it (clock skew, revoked session,
+                    # token expired while request was in flight) - refresh and repeat the request once, before callbacks and before raising
+                    if (
+                        isinstance(exception, (AccessTokenExpiredError, InvalidAccessTokenError))
+                        and not reauthed
+                        and name != 'refresh_token'
+                        and client.can_refresh_auth
+                    ):
+                        reauthed = True
+                        if not client.is_token_expired(margin=0):
+                            l.warning(
+                                'server rejected access_token that is not expired by local clock (expires at %s, now is %s): '
+                                'check system time (clock skew) or session was revoked',
+                                client.access_token_data.expired_at if client.access_token_data else None,
+                                datetime.now()
+                            )
+                        l.warning('%s on %s: refresh access_token and retry', exception.__class__.__name__, name)
+                        client.refresh_auth(force=True)
+                        return exec()
+
+                    client._process_exc_callbacks(exception)
+                    raise exception
+
+                if client.config.debug_response == DebugResponseMode.AFTER:
+                    l.debug('response: %s', json)
+                if client.config.debug_response == DebugResponseMode.KEYS:
+                    if 'data' in json:
+                        l.debug('response keys: data - %s', list(json['data'].keys()))
+                    else:
+                        l.debug('response keys: %s', list(json.keys()))
+                res.raise_for_status()
+                return res
+
+            if not client.config._retry_enabled:
+                return exec()
+
+            while True:
+                try:
+                    return exec()
+                except client.config._retry_exceptions as e:
+                    if getattr(e, 'retry_after', 0) > client.config.retry_max_retry_after:
+                        l.error('too large rate limit')
+                        raise
+
+                    retry_after = getattr(e, 'retry_after', 0) or client.config.retry_delay
+                    l.warning('%s on %s: wait %ss', e.__class__.__name__, name, retry_after)
+                    sleep(retry_after)
+                    if name in limits and limits[name] in limiters:
+                        limiters[limits[name]].on_limit()
+
+        return wrapper
+
+    return decorator
+
+
+catch_errors = api_wrapper
+
+
+@dataclass
+class Endpoint:
+    """Описание эндпоинта, доступно как атрибут `.endpoint` у декорированной функции"""
+
+    method: str
+    url: str
+    level: AuthLevel
+    exceptions: tuple[ITDException, ...]
+
+
+def endpoint(method: str, url: str, *exceptions: ITDException, level: AuthLevel = AuthLevel.ACCESS):
+    """Объявить эндпоинт: декорированная функция только собирает тело запроса (dict с параметрами, Payload или ничего),
+    а отправку, авторизацию, лимиты и ошибки берет на себя пайплайн
+
+    Args:
+        method (str): Метод
+        url (str): URL, может содержать имена аргументов функции: 'posts/{post_id}/comments'
+        *exceptions (ITDException): Ошибки, специфичные для эндпоинта (общие проверяются всегда)
+        level (AuthLevel, optional): Требуемый уровень авторизации. Defaults to AuthLevel.ACCESS.
+    """
+
+    def decorator(func: Callable[..., dict | Payload | None]):
+        params = signature(func) if '{' in url else None  # аргументы нужно связывать, только если url шаблонный
+
+        @wraps(func)
+        def request(client: 'Client', *args, **kwargs) -> Response:
+            payload = func(client, *args, **kwargs) or Payload()
+            if isinstance(payload, dict):
+                payload = Payload(payload)
+
+            if params is None:
+                path = url
+            else:
+                bound = params.bind(client, *args, **kwargs)
+                bound.apply_defaults()
+                path = url.format(**bound.arguments)
+
+            return client.request(method, path, payload.params, payload.files, level=level)
+
+        wrapper = api_wrapper(*exceptions)(request)
+        wrapper.endpoint = Endpoint(method, url, level, exceptions)
+        return wrapper
+
+    return decorator
+
+
+def rate_limit():
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(client: 'Client', *args, **kwargs) -> Response | None:
+            l.warning('rate_limit is deprecated and will be removed in 2.7.0.')
+            return func(client, *args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ from os import getenv
 import pytest
 from dotenv import load_dotenv
 
+from helpers import make_response, make_token
+
 from itd import ITDClient, ITDConfig
 from itd.enums import RateLimitMode
 from itd.post import Post
@@ -39,3 +41,42 @@ def client_sub(client):
 @pytest.fixture(scope="session")
 def redis_post(client):  # думаешь redis это какое нибудь заумное важное название? а нет, это просто редис зплвца
     return Post('1cbe5926-2d08-4e17-879d-7732b94ed354')
+
+
+# фикстуры для оффлайн тестов (test_auth, test_endpoint, test_errors)
+
+
+@pytest.fixture
+def keep_default_client():
+    """Клиенты оффлайн тестов не должны становиться дефолтными для остальных"""
+    from itd import _default
+
+    previous = _default._default_client
+    yield
+    _default._default_client = previous
+
+
+@pytest.fixture
+def fetches(monkeypatch):
+    """Перехватить запросы вместо отправки"""
+    calls = []
+
+    def fake_fetch(client, method, url, params={}, files={}, send_token=True):
+        calls.append({'method': method, 'url': url, 'params': params, 'files': files, 'send_token': send_token})
+        return make_response(200, {'data': {}})
+
+    monkeypatch.setattr('itd.client.fetch', fake_fetch)
+    return calls
+
+
+@pytest.fixture
+def refreshes(monkeypatch):
+    """Перехватить обновление токена вместо запроса в v1/auth/refresh"""
+    calls = []
+
+    def fake_refresh_token(client):
+        calls.append(client.access_token)
+        return make_response(200, {'accessToken': make_token(900)})
+
+    monkeypatch.setattr('itd.client.refresh_token', fake_refresh_token)
+    return calls

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,34 @@
+"""Хелперы для оффлайн тестов (без сети и без TOKEN)"""
+
+from base64 import urlsafe_b64encode
+from datetime import datetime, timedelta
+from json import dumps
+from uuid import uuid4
+
+from requests import Response
+
+from itd.client import Client, Config
+
+
+def make_token(expires_in: float) -> str:
+    """Собрать access token (jwt), который истечет через `expires_in` секунд"""
+    payload = {
+        'sid': str(uuid4()),
+        'sub': str(uuid4()),
+        'iat': datetime.now().timestamp(),
+        'exp': (datetime.now() + timedelta(seconds=expires_in)).timestamp()
+    }
+    encoded = urlsafe_b64encode(dumps(payload).encode()).decode().rstrip('=')
+    return f'header.{encoded}.signature'
+
+
+def make_response(status: int, json: dict) -> Response:
+    res = Response()
+    res.status_code = status
+    res._content = dumps(json).encode()
+    return res
+
+
+def make_client(access: str | None = None, refresh: str | None = 'refresh-token') -> Client:
+    # timers are disabled so client doesnt go to network
+    return Client(refresh, access, config=Config(dwell_send_interval=0, post_update_stats=False, dwell_check_active=False))

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,7 @@
 from base64 import urlsafe_b64encode
 from datetime import datetime, timedelta
 from json import dumps
+from logging import WARNING, getLogger
 from uuid import uuid4
 
 import pytest
@@ -42,7 +43,7 @@ def keep_default_client():
 
 
 def make_client(access: str | None = None, refresh: str | None = 'refresh-token') -> Client:
-    # таймеры выключены, чтобы клиент не ходил в сеть
+    # timers are disabled so client doesnt go to network
     return Client(refresh, access, config=Config(dwell_send_interval=0, post_update_stats=False, dwell_check_active=False))
 
 
@@ -74,7 +75,7 @@ def refreshes(monkeypatch):
 
 def test_is_token_expired():
     assert make_client(make_token(-10)).is_token_expired()
-    assert make_client(make_token(30)).is_token_expired()  # истечет раньше, чем пройдет запас (token_expiry_margin)
+    assert make_client(make_token(30)).is_token_expired()  # expires sooner than token_expiry_margin
     assert not make_client(make_token(900)).is_token_expired()
     assert make_client(None).is_token_expired()
 
@@ -123,7 +124,7 @@ def test_refresh_auth_skips_request_if_token_is_fresh(refreshes):
     client = make_client(make_token(900))
 
     assert client.refresh_auth() == client.access_token
-    assert refreshes == []  # уже обновлен (например другим потоком)
+    assert refreshes == []  # already fresh (eg refreshed by another thread)
 
     client.refresh_auth(force=True)
     assert len(refreshes) == 1
@@ -151,6 +152,24 @@ def test_api_wrapper_retries_after_token_expired(fetches, refreshes):
     assert len(refreshes) == 1
 
 
+@pytest.mark.parametrize(('expires_in', 'warned'), [(900, True), (-10, False)])
+def test_api_wrapper_warns_if_token_rejected_but_not_expired(fetches, refreshes, caplog, expires_in, warned):
+    """Если по нашим часам токен еще жив, а сервер его отверг - предупреждаем (расхождение часов / отозванная сессия)"""
+    getLogger('itd').propagate = True
+    client = make_client(make_token(expires_in))
+    responses = [make_response(401, {'error': 'token expired'}), make_response(200, {'data': {}})]
+
+    @api_wrapper()
+    def get_something(client: Client):
+        return responses.pop(0)
+
+    with caplog.at_level(WARNING, logger='itd.base'):
+        get_something(client)
+
+    assert any('clock skew' in record.getMessage() for record in caplog.records) is warned
+    assert len(refreshes) == 1
+
+
 def test_api_wrapper_raises_if_retry_failed(fetches, refreshes):
     client = make_client(make_token(900))
 
@@ -161,7 +180,7 @@ def test_api_wrapper_raises_if_retry_failed(fetches, refreshes):
     with pytest.raises(AccessTokenExpiredError):
         get_something(client)
 
-    assert len(refreshes) == 1  # обновляем и повторяем только один раз
+    assert len(refreshes) == 1  # refresh and retry only once
 
 
 def test_api_wrapper_does_not_retry_without_refresh_token(fetches, refreshes):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,76 +1,14 @@
-from base64 import urlsafe_b64encode
-from datetime import datetime, timedelta
-from json import dumps
 from logging import WARNING, getLogger
-from uuid import uuid4
 
 import pytest
-from requests import Response
+from helpers import make_client, make_response, make_token
 
-from itd.base import api_wrapper
-from itd.client import Client, Config
+from itd.client import Client
 from itd.enums import AuthLevel
 from itd.exceptions import AccessTokenExpiredError
+from itd.request import api_wrapper
 
-
-def make_token(expires_in: float) -> str:
-    """Собрать access token (jwt), который истечет через `expires_in` секунд"""
-    payload = {
-        'sid': str(uuid4()),
-        'sub': str(uuid4()),
-        'iat': datetime.now().timestamp(),
-        'exp': (datetime.now() + timedelta(seconds=expires_in)).timestamp()
-    }
-    encoded = urlsafe_b64encode(dumps(payload).encode()).decode().rstrip('=')
-    return f'header.{encoded}.signature'
-
-
-def make_response(status: int, json: dict) -> Response:
-    res = Response()
-    res.status_code = status
-    res._content = dumps(json).encode()
-    return res
-
-
-@pytest.fixture(autouse=True)
-def keep_default_client():
-    """Клиенты из этого файла не должны становиться дефолтными для остальных тестов"""
-    from itd import _default
-
-    previous = _default._default_client
-    yield
-    _default._default_client = previous
-
-
-def make_client(access: str | None = None, refresh: str | None = 'refresh-token') -> Client:
-    # timers are disabled so client doesnt go to network
-    return Client(refresh, access, config=Config(dwell_send_interval=0, post_update_stats=False, dwell_check_active=False))
-
-
-@pytest.fixture
-def fetches(monkeypatch):
-    """Перехватить запросы вместо отправки"""
-    calls = []
-
-    def fake_fetch(client, method, url, params={}, files={}, send_token=True):
-        calls.append({'method': method, 'url': url, 'send_token': send_token})
-        return make_response(200, {'data': {}})
-
-    monkeypatch.setattr('itd.client.fetch', fake_fetch)
-    return calls
-
-
-@pytest.fixture
-def refreshes(monkeypatch):
-    """Перехватить обновление токена вместо запроса в v1/auth/refresh"""
-    calls = []
-
-    def fake_refresh_token(client):
-        calls.append(client.access_token)
-        return make_response(200, {'accessToken': make_token(900)})
-
-    monkeypatch.setattr('itd.client.refresh_token', fake_refresh_token)
-    return calls
+pytestmark = pytest.mark.usefixtures('keep_default_client')
 
 
 def test_is_token_expired():
@@ -88,7 +26,7 @@ def test_public_endpoint_refreshes_expired_token(fetches, refreshes):
     client.request('get', 'search', {'q': 'итд'}, level=AuthLevel.NO)
 
     assert refreshes == [expired]
-    assert fetches == [{'method': 'get', 'url': 'search', 'send_token': True}]
+    assert fetches[0]['send_token'] is True
     assert not client.is_token_expired()
 
 
@@ -117,7 +55,7 @@ def test_refresh_endpoint_does_not_recurse(fetches, refreshes):
     client.request('post', 'v1/auth/refresh', level=AuthLevel.REFRESH)
 
     assert refreshes == []
-    assert fetches == [{'method': 'post', 'url': 'v1/auth/refresh', 'send_token': True}]
+    assert fetches[0]['url'] == 'v1/auth/refresh'
 
 
 def test_refresh_auth_skips_request_if_token_is_fresh(refreshes):
@@ -136,7 +74,7 @@ def test_expired_token_without_refresh_token_is_not_sent(fetches):
 
     client.request('get', 'search', {'q': 'итд'}, level=AuthLevel.NO)
 
-    assert fetches == [{'method': 'get', 'url': 'search', 'send_token': False}]
+    assert fetches[0]['send_token'] is False
 
 
 def test_api_wrapper_retries_after_token_expired(fetches, refreshes):
@@ -163,7 +101,7 @@ def test_api_wrapper_warns_if_token_rejected_but_not_expired(fetches, refreshes,
     def get_something(client: Client):
         return responses.pop(0)
 
-    with caplog.at_level(WARNING, logger='itd.base'):
+    with caplog.at_level(WARNING, logger='itd.request'):
         get_something(client)
 
     assert any('clock skew' in record.getMessage() for record in caplog.records) is warned

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,177 @@
+from base64 import urlsafe_b64encode
+from datetime import datetime, timedelta
+from json import dumps
+from uuid import uuid4
+
+import pytest
+from requests import Response
+
+from itd.base import api_wrapper
+from itd.client import Client, Config
+from itd.enums import AuthLevel
+from itd.exceptions import AccessTokenExpiredError
+
+
+def make_token(expires_in: float) -> str:
+    """Собрать access token (jwt), который истечет через `expires_in` секунд"""
+    payload = {
+        'sid': str(uuid4()),
+        'sub': str(uuid4()),
+        'iat': datetime.now().timestamp(),
+        'exp': (datetime.now() + timedelta(seconds=expires_in)).timestamp()
+    }
+    encoded = urlsafe_b64encode(dumps(payload).encode()).decode().rstrip('=')
+    return f'header.{encoded}.signature'
+
+
+def make_response(status: int, json: dict) -> Response:
+    res = Response()
+    res.status_code = status
+    res._content = dumps(json).encode()
+    return res
+
+
+@pytest.fixture(autouse=True)
+def keep_default_client():
+    """Клиенты из этого файла не должны становиться дефолтными для остальных тестов"""
+    from itd import _default
+
+    previous = _default._default_client
+    yield
+    _default._default_client = previous
+
+
+def make_client(access: str | None = None, refresh: str | None = 'refresh-token') -> Client:
+    # таймеры выключены, чтобы клиент не ходил в сеть
+    return Client(refresh, access, config=Config(dwell_send_interval=0, post_update_stats=False, dwell_check_active=False))
+
+
+@pytest.fixture
+def fetches(monkeypatch):
+    """Перехватить запросы вместо отправки"""
+    calls = []
+
+    def fake_fetch(client, method, url, params={}, files={}, send_token=True):
+        calls.append({'method': method, 'url': url, 'send_token': send_token})
+        return make_response(200, {'data': {}})
+
+    monkeypatch.setattr('itd.client.fetch', fake_fetch)
+    return calls
+
+
+@pytest.fixture
+def refreshes(monkeypatch):
+    """Перехватить обновление токена вместо запроса в v1/auth/refresh"""
+    calls = []
+
+    def fake_refresh_token(client):
+        calls.append(client.access_token)
+        return make_response(200, {'accessToken': make_token(900)})
+
+    monkeypatch.setattr('itd.client.refresh_token', fake_refresh_token)
+    return calls
+
+
+def test_is_token_expired():
+    assert make_client(make_token(-10)).is_token_expired()
+    assert make_client(make_token(30)).is_token_expired()  # истечет раньше, чем пройдет запас (token_expiry_margin)
+    assert not make_client(make_token(900)).is_token_expired()
+    assert make_client(None).is_token_expired()
+
+
+def test_public_endpoint_refreshes_expired_token(fetches, refreshes):
+    """Токен подставляется и в запросы без авторизации (search, hashtags, profile), поэтому его надо обновлять и для них"""
+    client = make_client(make_token(-10))
+    expired = client.access_token
+
+    client.request('get', 'search', {'q': 'итд'}, level=AuthLevel.NO)
+
+    assert refreshes == [expired]
+    assert fetches == [{'method': 'get', 'url': 'search', 'send_token': True}]
+    assert not client.is_token_expired()
+
+
+def test_endpoint_with_auth_refreshes_expired_token(fetches, refreshes):
+    client = make_client(make_token(-10))
+
+    client.request('get', 'profile/me', level=AuthLevel.ACCESS)
+
+    assert len(refreshes) == 1
+    assert not client.is_token_expired()
+
+
+def test_fresh_token_is_not_refreshed(fetches, refreshes):
+    client = make_client(make_token(900))
+
+    client.request('get', 'search', {'q': 'итд'}, level=AuthLevel.NO)
+    client.request('get', 'profile/me', level=AuthLevel.ACCESS)
+
+    assert refreshes == []
+    assert len(fetches) == 2
+
+
+def test_refresh_endpoint_does_not_recurse(fetches, refreshes):
+    client = make_client(make_token(-10))
+
+    client.request('post', 'v1/auth/refresh', level=AuthLevel.REFRESH)
+
+    assert refreshes == []
+    assert fetches == [{'method': 'post', 'url': 'v1/auth/refresh', 'send_token': True}]
+
+
+def test_refresh_auth_skips_request_if_token_is_fresh(refreshes):
+    client = make_client(make_token(900))
+
+    assert client.refresh_auth() == client.access_token
+    assert refreshes == []  # уже обновлен (например другим потоком)
+
+    client.refresh_auth(force=True)
+    assert len(refreshes) == 1
+
+
+def test_expired_token_without_refresh_token_is_not_sent(fetches):
+    """Обновить токен нечем - для эндпоинта без авторизации лучше сходить анонимно, чем послать протухший токен"""
+    client = make_client(make_token(-10), refresh=None)
+
+    client.request('get', 'search', {'q': 'итд'}, level=AuthLevel.NO)
+
+    assert fetches == [{'method': 'get', 'url': 'search', 'send_token': False}]
+
+
+def test_api_wrapper_retries_after_token_expired(fetches, refreshes):
+    """Сервер может отвергнуть токен, который по нашим часам еще жив"""
+    client = make_client(make_token(900))
+    responses = [make_response(401, {'error': 'token expired'}), make_response(200, {'data': {}})]
+
+    @api_wrapper()
+    def get_something(client: Client):
+        return responses.pop(0)
+
+    assert get_something(client).status_code == 200
+    assert len(refreshes) == 1
+
+
+def test_api_wrapper_raises_if_retry_failed(fetches, refreshes):
+    client = make_client(make_token(900))
+
+    @api_wrapper()
+    def get_something(client: Client):
+        return make_response(401, {'error': 'token expired'})
+
+    with pytest.raises(AccessTokenExpiredError):
+        get_something(client)
+
+    assert len(refreshes) == 1  # обновляем и повторяем только один раз
+
+
+def test_api_wrapper_does_not_retry_without_refresh_token(fetches, refreshes):
+    client = make_client(make_token(900), refresh=None)
+
+    @api_wrapper()
+    def get_something(client: Client):
+        return make_response(401, {'error': 'token expired'})
+
+    with pytest.raises(AccessTokenExpiredError):
+        get_something(client)
+
+    assert refreshes == []

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -1,0 +1,108 @@
+from importlib import import_module
+from inspect import signature
+from string import Formatter
+from uuid import uuid4
+
+import pytest
+from helpers import make_client, make_response, make_token
+
+from itd.api.auth import logout
+from itd.api.comments import get_comments
+from itd.api.files import upload_file
+from itd.api.pins import get_pins
+from itd.api.posts import get_user_posts, like_post
+from itd.exceptions import InsufficientAuthLevelError
+
+pytestmark = pytest.mark.usefixtures('keep_default_client')
+
+
+def test_url_is_filled_from_arguments(fetches):
+    client = make_client(make_token(900))
+    id = uuid4()
+
+    like_post(client, id)
+
+    assert fetches[0]['method'] == 'post'
+    assert fetches[0]['url'] == f'posts/{id}/like'
+    assert fetches[0]['params'] == {}
+
+
+def test_params_are_returned_by_function(fetches):
+    client = make_client(make_token(900))
+    post_id = uuid4()
+
+    get_comments(client, post_id, cursor=5, limit=50)
+
+    assert fetches[0]['url'] == f'posts/{post_id}/comments'
+    assert fetches[0]['params'] == {'limit': 50, 'sort': 'popular', 'cursor': 5}
+
+
+def test_default_arguments_are_used_in_url_and_params(fetches):
+    client = make_client(make_token(900))
+
+    get_user_posts(client, 'itd')
+
+    assert fetches[0]['url'] == 'posts/user/itd'
+    assert fetches[0]['params']['limit'] == 20
+    assert fetches[0]['params']['sort'] == 'new'
+
+
+def test_endpoint_without_body_sends_no_params(fetches):
+    client = make_client(make_token(900))
+
+    get_pins(client)
+
+    assert fetches[0] == {'method': 'get', 'url': 'users/me/pins', 'params': {}, 'files': {}, 'send_token': True}
+
+
+def test_endpoint_can_send_files(fetches):
+    client = make_client(make_token(900))
+
+    upload_file(client, 'pic.png', b'123')
+
+    assert fetches[0]['files'] == {'file': ('pic.png', b'123')}
+    assert fetches[0]['params'] == {}
+
+
+def test_search_from_client_goes_through_pipeline(monkeypatch, refreshes):
+    """Путь целиком: Client.search -> эндпоинт search -> Client.request (обновление токена) -> fetch"""
+    client = make_client(make_token(-10))
+    calls = []
+
+    def fake_fetch(client, method, url, params={}, files={}, send_token=True):
+        calls.append((method, url, params, send_token))
+        return make_response(200, {'data': {'users': [], 'hashtags': []}})
+
+    monkeypatch.setattr('itd.client.fetch', fake_fetch)
+
+    assert client.search('итд', hashtags_limit=3, users_limit=2) == ([], [])
+    assert calls == [('get', 'search', {'userLimit': 2, 'hashtagLimit': 3, 'q': 'итд'}, True)]
+    assert len(refreshes) == 1  # протухший токен обновлен, хотя эндпоинт с AuthLevel.NO
+
+
+def test_all_url_templates_match_signatures():
+    """Все имена в шаблонах url должны быть аргументами своих функций"""
+    checked = 0
+    for name in ('auth', 'comments', 'dwell', 'etc', 'files', 'hashtags', 'notifications', 'pins', 'platform', 'polls', 'portal', 'posts', 'reports',
+                 'search', 'sessions', 'subscription', 'users', 'verification'):
+        module = import_module(f'itd.api.{name}')
+        for func in vars(module).values():
+            declaration = getattr(func, 'endpoint', None)
+            if declaration is None:
+                continue
+
+            fields = {field for _, field, _, _ in Formatter().parse(declaration.url) if field}
+            assert fields <= set(signature(func).parameters), f'{func.__name__}: {declaration.url}'
+            checked += 1
+
+    assert checked > 50
+
+
+def test_endpoint_requires_declared_auth_level(fetches):
+    """logout объявлен с AuthLevel.REFRESH, а у клиента только access token"""
+    client = make_client(make_token(900), refresh=None)
+
+    with pytest.raises(InsufficientAuthLevelError):
+        logout(client)
+
+    assert fetches == []

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,65 @@
+import pytest
+from helpers import make_response
+
+from itd.exceptions import DEFAULT_ERRORS, AccountDeletedError, NotFoundError, RateLimitError, ValidationError
+from itd.request import _find_error
+
+
+def find(status: int, json: dict, *declarations):
+    return _find_error(make_response(status, json), json, declarations)
+
+
+def test_no_error_for_successful_response():
+    assert find(200, {'data': {'id': 1}}, ValidationError()) is None
+
+
+def test_error_is_matched_by_code():
+    exception = find(404, {'error': {'code': 'NOT_FOUND'}}, NotFoundError('Post'))
+
+    assert isinstance(exception, NotFoundError)
+    assert str(exception) == 'Post not found'  # аргументы декларации не теряются при копировании
+
+
+def test_declaration_is_not_mutated():
+    declaration = ValidationError()
+
+    exception = find(422, {'error': {'code': 'VALIDATION_ERROR', 'message': 'Слишком длинный пост'}}, declaration)
+
+    assert str(exception) == 'Слишком длинный пост'
+    assert exception is not declaration
+    assert declaration.text == 'Failed validation'  # декларация переиспользуется между запросами, ее нельзя менять
+
+
+def test_rate_limit_retry_after_is_filled():
+    exception = find(429, {'error': {'code': 'RATE_LIMIT_EXCEEDED', 'retryAfter': 5}})
+
+    assert isinstance(exception, RateLimitError)
+    assert exception.retry_after == 5
+    assert next(declaration for declaration in DEFAULT_ERRORS if isinstance(declaration, RateLimitError)).retry_after == 0
+
+
+def test_account_deleted_can_restore_is_filled():
+    exception = find(403, {'error': {'code': 'ACCOUNT_DELETED', 'canRestore': False}})
+
+    assert isinstance(exception, AccountDeletedError)
+    assert exception.can_restore is False
+
+
+def test_string_error_does_not_break_matching():
+    """['error'] не всегда объект - иногда просто строка"""
+    exception = find(429, {'error': 'Too Many Requests'})
+
+    assert isinstance(exception, RateLimitError)
+    assert exception.retry_after == 0
+
+
+@pytest.mark.parametrize(
+    ('declaration', 'status', 'json'),
+    [
+        (NotFoundError('User', res_check=lambda res: res.status_code == 500), 500, {}),
+        (NotFoundError('Hashtag', json_check=lambda json: json.get('data', {}).get('hashtag') is None), 200, {'data': {'hashtag': None}}),
+        (NotFoundError('Poll', 'Опрос не найден'), 400, {'error': {'message': 'Опрос не найден'}})
+    ]
+)
+def test_all_check_kinds_are_supported(declaration, status, json):
+    assert isinstance(find(status, json, declaration), NotFoundError)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,9 +1,10 @@
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
+from helpers import make_client, make_response, make_token
 
+from itd._default import set_default_client
 from itd.exceptions import PinNotOwnedError
-from itd.pin import Pin
 from itd.user import Followers, Following, Me, User
 
 
@@ -17,16 +18,43 @@ def me2(client2):
     return Me(client2)
 
 
-def test_by_username_is_lazy():
+@pytest.fixture
+def default_client(keep_default_client):
+    """Ленивым тестам нужен только дефолтный клиент: в сеть они не ходят, поэтому TOKEN не нужен"""
+    client = make_client(make_token(900))
+    set_default_client(client)
+    return client
+
+
+def test_by_username_is_lazy(default_client, fetches):
     user = User.by_username('example')
     assert user.username == 'example'
     assert user._identifier == 'example'
+    assert fetches == []
 
 
-def test_by_id_is_lazy():
+def test_by_id_is_lazy(default_client, fetches):
     uid = UUID('00000000-0000-0000-0000-000000000001')
     user = User.by_id(uid)
     assert user.id == uid
+    assert fetches == []
+
+
+def test_not_loaded_field_still_refreshes(default_client, monkeypatch):
+    """Лениво отдаются только те поля, которые задали сами - за остальными модель идет в апи"""
+    uid = uuid4()
+    calls = []
+
+    def fake_fetch(client, method, url, params={}, files={}, send_token=True):
+        calls.append(url)
+        return make_response(200, {'id': str(uid), 'username': 'example', 'displayName': 'Example'})
+
+    monkeypatch.setattr('itd.client.fetch', fake_fetch)
+
+    user = User.by_username('example')
+    assert user.display_name == 'Example'
+    assert user.id == uid
+    assert calls == ['users/example']
 
 
 def test_me_loads(me):


### PR DESCRIPTION
Токен подставлялся в каждый запрос, но обновлялся только перед
эндпоинтами с AuthLevel.ACCESS и выше. Из-за этого запросы к
эндпоинтам с AuthLevel.NO (search, hashtags, profile, portal) уходили
с протухшим Authorization и падали с AccessTokenExpiredError, как
только истекал access token - то есть через несколько часов работы
скрипта.

- обновляем токен перед любым запросом, в котором отправляется
  Authorization, а не только при level >= ACCESS
- если обновить нечем (нет refresh token), для эндпоинтов без
  авторизации отправляем запрос анонимно вместо протухшего токена
- добавлены Client.is_token_expired() и Client.can_refresh_auth,
  запас перед истечением вынесен в config.token_expiry_margin
  (раньше был захардкожен и не учитывался при чтении токена из файла)
- refresh_auth под локом с повторной проверкой: параллельные потоки
  (таймеры dwell/статистики) больше не обновляют токен одновременно
- api_wrapper обновляет токен и повторяет запрос один раз, если сервер
  все же отверг токен (расхождение часов, отозванная сессия)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

ебать клауд фиксанул все быстренько